### PR TITLE
Make sure HF download metrics work

### DIFF
--- a/unidepth/models/__init__.py
+++ b/unidepth/models/__init__.py
@@ -1,4 +1,4 @@
-from .unidepthv1 import UniDepthV1
+from .unidepthv1 import UniDepthV1, UniDepthV1HF
 
 __all__ = [
     "UniDepthV1",

--- a/unidepth/models/__init__.py
+++ b/unidepth/models/__init__.py
@@ -2,4 +2,5 @@ from .unidepthv1 import UniDepthV1
 
 __all__ = [
     "UniDepthV1",
+    "UniDepthV1HF",
 ]

--- a/unidepth/models/unidepthv1/__init__.py
+++ b/unidepth/models/unidepthv1/__init__.py
@@ -1,3 +1,3 @@
-from .unidepthv1 import UniDepthV1
+from .unidepthv1 import UniDepthV1, UniDepthV1HF
 
 __all__ = ["UniDepthV1", "UniDepthV1HF"]

--- a/unidepth/models/unidepthv1/__init__.py
+++ b/unidepth/models/unidepthv1/__init__.py
@@ -1,3 +1,3 @@
 from .unidepthv1 import UniDepthV1
 
-__all__ = ["UniDepthV1"]
+__all__ = ["UniDepthV1", "UniDepthV1HF"]

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -349,7 +349,7 @@ class UniDepthV1(nn.Module):
         )
 
 
-class UniDepthV1HF(PyTorchModelHubMixin, UniDepthV1):
+class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
     def __init__(self, config):
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])
@@ -376,3 +376,7 @@ class UniDepthV1HF(PyTorchModelHubMixin, UniDepthV1):
 
         pixel_decoder = Decoder.build(config)
         super().__init__(pixel_encoder, pixel_decoder, image_shape=config["data"]["image_shape"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return super(PyTorchModelHubMixin, cls).from_pretrained(*args, **kwargs)

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -377,5 +377,7 @@ class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
         pixel_decoder = Decoder.build(config)
         super().__init__(pixel_encoder, pixel_decoder, image_shape=config["data"]["image_shape"])
 
-    def from_pretrained(self, pretrained_model_name_or_path):
-        return super(PyTorchModelHubMixin, self).from_pretrained(pretrained_model_name_or_path)
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path):
+        # pass to the from_pretrained of PyTorcModelHubMixin
+        return super().from_pretrained(pretrained_model_name_or_path)

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -380,4 +380,4 @@ class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path):
         # pass to the from_pretrained of PyTorcModelHubMixin
-        return super().from_pretrained(pretrained_model_name_or_path)
+        return super(PyTorchModelHubMixin).from_pretrained(pretrained_model_name_or_path)

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -350,7 +350,7 @@ class UniDepthV1(nn.Module):
 
 
 class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin,
-                   library_name="keras-nlp",
+                   library_name="UniDepth",
                    repo_url="https://github.com/lpiccinelli-eth/UniDepth",
                    docs_url="https://github.com/lpiccinelli-eth/UniDepth?tab=readme-ov-file#unidepth-universal-monocular-metric-depth-estimation",):
     def __init__(self, config):

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -4,6 +4,7 @@ Licensed under the CC-BY NC 4.0 license (http://creativecommons.org/licenses/by-
 """
 
 from copy import deepcopy
+import importlib
 from typing import Any, Dict, Tuple
 from math import ceil
 
@@ -21,6 +22,8 @@ from unidepth.utils.misc import get_params
 from unidepth.utils.distributed import is_main_process
 from unidepth.utils.constants import IMAGENET_DATASET_MEAN, IMAGENET_DATASET_STD
 from unidepth.models.unidepthv1.decoder import Decoder
+
+from huggingface_hub import PyTorchModelHubMixin
 
 
 MAP_BACKBONES = {"ViTL14": "vitl14", "ConvNextL": "cnvnxtl"}
@@ -314,8 +317,6 @@ class UniDepthV1(nn.Module):
 
     @classmethod
     def build(cls, config: Dict[str, Dict[str, Any]]):
-        import importlib
-
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])
         pixel_encoder_config = {
@@ -346,3 +347,32 @@ class UniDepthV1(nn.Module):
             pixel_decoder=pixel_decoder,
             image_shape=config["data"]["image_shape"],
         )
+
+
+class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
+    def __init__(self, config):
+        mod = importlib.import_module("unidepth.models.encoder")
+        pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])
+        pixel_encoder_config = {
+            **config["training"],
+            **config["data"],
+            **config["model"]["pixel_encoder"],
+        }
+        pixel_encoder = pixel_encoder_factory(pixel_encoder_config)
+
+        config["model"]["pixel_encoder"]["patch_size"] = (
+            14 if "dino" in config["model"]["pixel_encoder"]["name"] else 16
+        )
+        pixel_encoder_embed_dims = (
+            pixel_encoder.embed_dims
+            if hasattr(pixel_encoder, "embed_dims")
+            else [getattr(pixel_encoder, "embed_dim") * 2**i for i in range(4)]
+        )
+        config["model"]["pixel_encoder"]["embed_dim"] = getattr(
+            pixel_encoder, "embed_dim"
+        )
+        config["model"]["pixel_encoder"]["embed_dims"] = pixel_encoder_embed_dims
+        config["model"]["pixel_encoder"]["depths"] = pixel_encoder.depths
+
+        pixel_decoder = Decoder.build(config)
+        super().__init__(pixel_encoder, pixel_decoder, image_shape=config["data"]["image_shape"])

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -376,3 +376,6 @@ class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
 
         pixel_decoder = Decoder.build(config)
         super().__init__(pixel_encoder, pixel_decoder, image_shape=config["data"]["image_shape"])
+
+    def from_pretrained(self, pretrained_model_name_or_path):
+        return super(PyTorchModelHubMixin, self).from_pretrained(pretrained_model_name_or_path)

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -352,7 +352,7 @@ class UniDepthV1(nn.Module):
 class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin,
                    library_name="UniDepth",
                    repo_url="https://github.com/lpiccinelli-eth/UniDepth",
-                   docs_url="https://github.com/lpiccinelli-eth/UniDepth?tab=readme-ov-file#unidepth-universal-monocular-metric-depth-estimation",):
+                   tags=["monocular-metric-depth-estimation"]):
     def __init__(self, config):
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -349,7 +349,10 @@ class UniDepthV1(nn.Module):
         )
 
 
-class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
+class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin,
+                   library_name="keras-nlp",
+                   repo_url="https://github.com/lpiccinelli-eth/UniDepth",
+                   docs_url="https://github.com/lpiccinelli-eth/UniDepth?tab=readme-ov-file#unidepth-universal-monocular-metric-depth-estimation",):
     def __init__(self, config):
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])

--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -349,7 +349,7 @@ class UniDepthV1(nn.Module):
         )
 
 
-class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
+class UniDepthV1HF(PyTorchModelHubMixin, UniDepthV1):
     def __init__(self, config):
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])
@@ -376,8 +376,3 @@ class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
 
         pixel_decoder = Decoder.build(config)
         super().__init__(pixel_encoder, pixel_decoder, image_shape=config["data"]["image_shape"])
-
-    @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path):
-        # pass to the from_pretrained of PyTorcModelHubMixin
-        return super(PyTorchModelHubMixin).from_pretrained(pretrained_model_name_or_path)


### PR DESCRIPTION
Dear authors,

I noticed your awesome repository trending on X. I see you already leverage `hf_hub_download`, however all checkpoints are present in a [single repository](https://huggingface.co/lpiccinelli/UniDepth), which means download metrics won't work. 😞 

This PR resolves that by showcasing the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class, which is a minimal class that allows to easily add functionalities like `from_pretrained`, `save_pretrained`, and `push_to_hub` to any custom `nn.Module` (without the need to rely on Torch hub or define your own `from_pretrained`). 

Similar to models in the Transformers/Diffusers library, it allows to push and reload models in the format of `safetensors` (for the weights) and a `config.json` (for the model's configuration). It also creates an automated model card, along with tags for better discoverability of your models. Usage is as follows:

```
from unidepth.models import UniDepthV1HF

model = UniDepthV1HF.from_pretrained("nielsr/unidepth-v1-convnext-large")
```
The corresponding model is here for now: https://huggingface.co/nielsr/unidepth-v1-convnext-large, but I could transfer it (along with the ViT-large checkpoint) to your organization.

Here's a [notebook](https://colab.research.google.com/drive/1B1Ej_GbKihb5_xE_x50Z_B3XyM0DNT_-?usp=sharing) regarding how I did that :)

Would you be interested in this integration?

Kind regards,

Niels
ML @ HF