### PR TITLE
Simplify things

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,21 +86,12 @@ If you encounter `Segmentation Fault` after running the demo, you may need to un
 
 ## Get Started
 
-After installing the dependencies, you can load the pre-trained models easily through TorchHub. For instance, if you want UniDepth v1 with Dino backbone:
-```python
-import torch
-
-version="v1"
-backbone="ViTL14"
-model = torch.hub.load("lpiccinelli-eth/UniDepth", "UniDepth", version=version, backbone=backbone, pretrained=True, trust_repo=True, force_reload=True)
-```
-
-or via HuggingFace API:
+After installing the dependencies, you can load the pre-trained models easily from [Hugging Face](https://huggingface.co/models?other=UniDepth) as follows:
 
 ```python
-from unidepth.models import UniDepthV1HF
+from unidepth.models import UniDepthV1
 
-model = UniDepthV1HF.from_pretrained(backbone="ViTL14")
+model = UniDepthV1.from_pretrained("lpiccinelli/unidepth-v1-vitl14") # or "lpiccinelli/unidepth-v1-cnvnxtl" for the ConvNext backbone
 ```
 
 Then you can generate the metric depth estimation and intrinsics prediction directly from RGB image only as follows:
@@ -150,27 +141,17 @@ data = {"image": rgb, "K": intrinsics}
 predictions = model(data, {})
 ```
 
-For easy-to-use, we provide our models via TorchHub where you need to specify version and backbone as:
+The models are available on [Hugging Face](https://huggingface.co/models?other=UniDepth). One can load a model as follows:
+
 ```python
-torch.hub.load("lpiccinelli-eth/UniDepth", "UniDepth", version=version, backbone=backbone, pretrained=True, trust_repo=True, force_reload=True)
+from unidepth.models import UniDepthV1
+
+model = UniDepthV1.from_pretrained("lpiccinelli/unidepth-v1-vitl14")
 ```
-
-For improved flexibility, we provide a UniDepth as HuggingFace model where you need to import the version wanted and specify the backbone:  
-```python
-from unidepth.models import UniDepthV1HF
-
-model = UniDepthV1HF.from_pretrained(backbone=backbone)
-```
-
-Mappings:  
-  - Version 1: version="v1"
-  - Version 2: version="v2"
-  - ViT Large: backbone="ViTL14"
-  - ConvNext Large: backbone="ConvNextL"
 
 For HuggingFace API you will need to import different UniDepth model for different versions.
 
-Please visit [HuggingFace](https://huggingface.co/lpiccinelli) to access the repo models with weights.
+Please visit [Hugging Face](https://huggingface.co/lpiccinelli) to access the repo models with weights.
 
 ## Results
 

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -3,6 +3,7 @@ import numpy as np
 from PIL import Image
 
 from unidepth.utils import colorize, image_grid
+from unidepth.models import UniDepthV1
 
 
 def demo(model):
@@ -36,18 +37,7 @@ def demo(model):
 
 if __name__ == "__main__":
     print("Torch version:", torch.__version__)
-    model = torch.hub.load(
-        "lpiccinelli-eth/unidepth",
-        "UniDepth",
-        backbone="ViTL14", # "ConvNextL
-        version="v1", # "v2"
-        pretrained=True,
-        trust_repo=True,
-        force_reload=True,
-    )
-    # or
-    # from unidepth.models import UniDepthV1HF
-    # model = UniDepthV1HF.from_pretrained(backbone="ViTL14")
+    model = UniDepthV1.from_pretrained("lpiccinelli/unidepth-v1-vitl14")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     demo(model)

--- a/unidepth/models/__init__.py
+++ b/unidepth/models/__init__.py
@@ -1,6 +1,5 @@
-from .unidepthv1 import UniDepthV1, UniDepthV1HF
+from .unidepthv1 import UniDepthV1
 
 __all__ = [
     "UniDepthV1",
-    "UniDepthV1HF"
 ]

--- a/unidepth/models/unidepthv1/__init__.py
+++ b/unidepth/models/unidepthv1/__init__.py
@@ -1,6 +1,5 @@
-from .unidepthv1 import UniDepthV1, UniDepthV1HF
+from .unidepthv1 import UniDepthV1
 
 __all__ = [
     "UniDepthV1",
-    "UniDepthV1HF"
 ]


### PR DESCRIPTION
This PR simplifies things by removing the `UniDepthV1HF` class, and instead just leverages the `UniDepth` class.

The hubconf.py file is still there for people that want to use it, but since that script itself uses hf_hub_download, it's quite straightforward to load one of the following models:

* https://huggingface.co/lpiccinelli/unidepth-v1-vitl14
* https://huggingface.co/nielsr/unidepth-v1-convnext-large