### PR TITLE
update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ ndindex
 networkx
 ninja
 numexpr
-numpy
+numpy~=1.26
 opencv-python
 OpenEXR
 packaging


### PR DESCRIPTION
The new numpy release version is not compatible with transformer module in `torch.nn.modules` as described this issue: https://github.com/lpiccinelli-eth/UniDepth/issues/58

This update will keep numpy 1.x (pulling the latest available).